### PR TITLE
Implementation for Comparable & Equatable Protocol

### DIFF
--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -169,6 +169,18 @@ extension NSDate {
 
 extension NSDate : _CFBridgable { }
 
+extension NSDate : Comparable, Equatable { }
+
+@warn_unused_result public func <(_ lhs: NSDate, _ rhs: NSDate) -> Bool
+{
+    return lhs.timeIntervalSinceReferenceDate < rhs.timeIntervalSinceReferenceDate
+}
+
+@warn_unused_result public func ==(_ lhs: NSDate, _ rhs: NSDate) -> Bool
+{
+    return lhs.timeIntervalSinceReferenceDate == rhs.timeIntervalSinceReferenceDate
+}
+
 extension CFDateRef : _NSBridgable {
     typealias NSType = NSDate
     internal var _nsObject: NSType { return unsafeBitCast(self, NSType.self) }


### PR DESCRIPTION
Added basic comparison operators.

Equatable has been explicitly declared as a conformed protocol, whilst this is implicitly declared by conforming to the Comparable protocol, adding the explicit declaration makes it more readable and understandable that this is the case.